### PR TITLE
Update to Orb 0.0.48

### DIFF
--- a/lib/misc.ex
+++ b/lib/misc.ex
@@ -3,15 +3,15 @@ defmodule Firefly.Misc do
 
   def log_debug(s) do
     Firefly.Bindings.Misc.log_debug(
-      Orb.Memory.Range.get_byte_offset(s),
-      Orb.Memory.Range.get_byte_length(s)
+      Orb.Memory.Slice.get_byte_offset(s),
+      Orb.Memory.Slice.get_byte_length(s)
     )
   end
 
   def log_error(s) do
     Firefly.Bindings.Misc.log_error(
-      Orb.Memory.Range.get_byte_offset(s),
-      Orb.Memory.Range.get_byte_length(s)
+      Orb.Memory.Slice.get_byte_offset(s),
+      Orb.Memory.Slice.get_byte_length(s)
     )
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Firefly.MixProject do
 
   defp deps do
     [
-      {:orb, "~> 0.0.46"},
+      {:orb, "~> 0.0.48"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -6,5 +6,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.2", "627e84b8e8bf22e60a2579dad15067c755531fea049ae26ef1020cad58fe9578", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "41193978704763f6bbe6cc2758b84909e62984c7752b3784bd3c218bb341706b"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.0", "6f0eff9c9c489f26b69b61440bf1b238d95badae49adac77973cbacae87e3c2e", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "ea7a9307de9d1548d2a72d299058d1fd2339e3d398560a0e46c27dab4891e4d2"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
-  "orb": {:hex, :orb, "0.0.46", "c5dcc8ee90287b11cd8e13c5ea7ecae9cc0196cdea7b3172669186480d53252b", [:mix], [], "hexpm", "2b93447e4ac923b793b691c7f5bd16d7c3b38d2b26287ef2813fc0665be1c7dc"},
+  "orb": {:hex, :orb, "0.0.48", "73ce7bab14466afe1f57a68a8e8795a54f767926781c7e35cb7303dcdd0ac673", [:mix], [], "hexpm", "0538dec83dede37c5ff01127e498d6cb4a6535309a6e49cff51fca543b6988c4"},
 }


### PR DESCRIPTION
A few things have changed:

- `Orb.Memory.Range` is `Orb.Memory.Slice`
- `Orb.Constants.NulTerminatedString` is now `Orb.Str`. This is what should be returned from functions, it gets compiled into a `(i32, i32)` tuple.

You might need some functions added to Orb to transform between an `Orb.Str` and `Orb.Memory.Slice` for that logging function, I can add it with the help of some context.